### PR TITLE
Use last-release-github for semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "image-webpack-loader": "^2.0.0",
     "istanbul": "^0.4.4",
     "json-loader": "^0.5.4",
-    "last-release-git-tag": "^1.0.1",
+    "last-release-github": "^1.1.1",
     "mocha": "^3.0.1",
     "nock": "^8.0.0",
     "node-fetch": "^1.6.0",
@@ -132,6 +132,6 @@
     "npm": "^3.9.0"
   },
   "release": {
-    "getLastRelease": "last-release-git-tag"
+    "getLastRelease": "last-release-github"
   }
 }


### PR DESCRIPTION
The other last-release plugin didn't work, but this one will (hopefully). It finds the version
locally, anyways.
